### PR TITLE
Adopt upstream changes 

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1054,26 +1054,6 @@
         "type": "github"
       }
     },
-    "nh": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1712645404,
-        "narHash": "sha256-uEVd15WsX+Wti9PXW724puFcsFO72VTiJyBwW2WXT9M=",
-        "owner": "viperML",
-        "repo": "nh",
-        "rev": "fe4a96a0b0b0662dba7c186b4a1746c70bbcad03",
-        "type": "github"
-      },
-      "original": {
-        "owner": "viperML",
-        "repo": "nh",
-        "type": "github"
-      }
-    },
     "niri": {
       "inputs": {
         "crane": [
@@ -1309,11 +1289,11 @@
     },
     "nixpkgs_11": {
       "locked": {
-        "lastModified": 1712703215,
-        "narHash": "sha256-kOQEMH+xCSYttVrRjMjMEaChhqatZp56fCOEmRrOQ+Y=",
+        "lastModified": 1713248628,
+        "narHash": "sha256-NLznXB5AOnniUtZsyy/aPWOk8ussTuePp2acb9U+ISA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "76b199e34be37ca7c807c6bd19872a9de0efc15b",
+        "rev": "5672bc9dbf9d88246ddab5ac454e82318d094bb8",
         "type": "github"
       },
       "original": {
@@ -1542,7 +1522,6 @@
         "kmonad": "kmonad",
         "lanzaboote": "lanzaboote",
         "matugen": "matugen",
-        "nh": "nh",
         "nix-gaming": "nix-gaming",
         "nix-index-db": "nix-index-db",
         "nix-matlab": "nix-matlab",

--- a/flake.nix
+++ b/flake.nix
@@ -106,11 +106,6 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
-    nh = {
-      url = "github:viperML/nh";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-
     nix-index-db = {
       url = "github:Mic92/nix-index-database";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/hosts/io/default.nix
+++ b/hosts/io/default.nix
@@ -8,10 +8,6 @@
   imports = [
     ./hardware-configuration.nix
     ./powersave.nix
-
-    # TODO: remove when https://github.com/NixOS/nixpkgs/pull/303186 lands in nixos-unstable
-    (lib.mkRenamedOptionModule ["services" "xserver" "displayManager" "sessionData"] ["services" "displayManager" "sessionData"])
-    (lib.mkRenamedOptionModule ["services" "xserver" "displayManager" "sessionPackages"] ["services" "displayManager" "sessionPackages"])
   ];
 
   age.secrets.spotify = {

--- a/system/nix/nh.nix
+++ b/system/nix/nh.nix
@@ -1,12 +1,8 @@
-{inputs, ...}: {
-  imports = [
-    inputs.nh.nixosModules.default
-  ];
-
+{pkgs, ...}: {
   # nh default flake
   environment.variables.FLAKE = "/home/mihai/Documents/code/dotfiles";
 
-  nh = {
+  programs.nh = {
     enable = true;
     # weekly cleanup
     clean = {


### PR DESCRIPTION
- Remove unnecessary Xserver option creation, following https://github.com/NixOS/nixpkgs/pull/303186
- Update to use nh from `nixpkgs` and update `nixpkgs`, removes nh as an input