### PR TITLE
Use home manager module for hyprpaper

### DIFF
--- a/home/services/wayland/hyprpaper.nix
+++ b/home/services/wayland/hyprpaper.nix
@@ -5,20 +5,13 @@
   config,
   ...
 }: {
-  xdg.configFile."hypr/hyprpaper.conf".text = ''
-    preload = ${config.theme.wallpaper}
-    wallpaper = , ${config.theme.wallpaper}
-  '';
+  services.hyprpaper = {
+    enable = true;
+    package = inputs.hyprpaper.packages.${pkgs.system}.default;
 
-  systemd.user.services.hyprpaper = {
-    Unit = {
-      Description = "Hyprland wallpaper daemon";
-      PartOf = ["graphical-session.target"];
+    settings = {
+      preload = [ "${config.theme.wallpaper}" ];
+      wallpaper = [ ", ${config.theme.wallpaper}" ];
     };
-    Service = {
-      ExecStart = "${lib.getExe inputs.hyprpaper.packages.${pkgs.system}.default}";
-      Restart = "on-failure";
-    };
-    Install.WantedBy = ["graphical-session.target"];
   };
 }


### PR DESCRIPTION
A [hyprpaper module](https://github.com/nix-community/home-manager/blob/master/modules/services/hyprpaper.nix) was added to home manager  :partying_face:

I believe you are a maintainer, but this saves you the work of swapping it in at least