### PR TITLE
Fix power-monitor initial run

### DIFF
--- a/home/services/system/power-monitor.nix
+++ b/home/services/system/power-monitor.nix
@@ -26,11 +26,9 @@
     	profile="$AC_PROFILE"
     fi
 
-    # set the new profile
-    if [ $prevProfile != "$profile" ]; then
-    	echo setting power profile to "$profile"
-    	powerprofilesctl set "$profile"
-    fi
+    # set the initial profile
+    echo setting power profile to "$profile"
+    powerprofilesctl set "$profile"
 
     prevProfile="$profile"
     prevStatus="$currentStatus"


### PR DESCRIPTION
First of all, thank you for your amazing config! During adaptation of some parts for my own config, I noticed that the service wouldn't set the initial power profile when on AC. The if statement for the initial run would evaluate to false when on AC power, and no initial profile would be set until status change.